### PR TITLE
退会機能の実装

### DIFF
--- a/app/Admin/Controllers/AuthController.php
+++ b/app/Admin/Controllers/AuthController.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Admin\Controllers;
 
 use Encore\Admin\Controllers\AuthController as BaseAuthController;

--- a/app/Admin/Controllers/AuthController.php
+++ b/app/Admin/Controllers/AuthController.php
@@ -1,5 +1,6 @@
 <?php
 
+
 namespace App\Admin\Controllers;
 
 use Encore\Admin\Controllers\AuthController as BaseAuthController;

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -36,5 +38,13 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    protected function authenticated(Request $request, $user)
+    {
+        if($user->deleted_flag) {
+            Auth::logout();
+            return redirect()->route('login')->with('warning', '退会済みのアカウントです。');
+        }
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -42,7 +42,7 @@ class LoginController extends Controller
 
     protected function authenticated(Request $request, $user)
     {
-        if($user->deleted_flag) {
+        if ($user->deleted_flag) {
             Auth::logout();
             return redirect()->route('login')->with('warning', '退会済みのアカウントです。');
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -91,11 +91,8 @@ class UserController extends Controller
     {
         $user = Auth::user();
 
-        if ($user->deleted_flag) {
-            $user->deleted_flag = false;
-        } else {
-            $user->deleted_flag = true;
-        }
+        $user->deleted_flag = !$user->deleted_flag;
+
         $user->update();
 
         Auth::logout();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -86,4 +86,19 @@ class UserController extends Controller
     {
         return view('users.edit_password');
     }
+
+    public function destroy(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->deleted_flag) {
+            $user->deleted_flag = false;
+        } else {
+            $user->deleted_flag = true;
+        }
+        $user->update();
+
+        Auth::logout();
+        return redirect('/');
+    }
 }

--- a/public/css/samuraimart.css
+++ b/public/css/samuraimart.css
@@ -208,3 +208,9 @@ label {
 .review-score-color:focus {
   color: #0fbe9f;
 }
+
+.samuraimart-delete-submit-button {
+  border-radius: 2px;
+  color: #ffffff;
+  background-color: #d94b0e;
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,6 +6,12 @@
         <div class="col-md-5">
             <h3 class="mt-3 mb-3">ログイン</h3>
 
+            @if (session('warning'))
+            <div class="alert alert-danger">
+                {{session('warning')}}
+            </div>
+            @endif
+
             <hr>
             <form method="POST" action="{{ route('login') }}">
                 @csrf

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -93,6 +93,35 @@
                     保存
                 </button>
             </form>
+
+            <hr>
+            <div class="d-flex justify-content-start">
+                <form method="POST" action="{{route('mypage.destroy')}}">
+                    @csrf
+                    @method('delete')
+                    <div class="btn dashboard-delete-link" data-bs-toggle="modal" data-bs-target="#delete-user-confirm-modal">退会する</div>
+
+                    <div class="modal fade" id="delete-user-confirm-modal" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="staticBackdropLabel"><label>本当に退会しますか？</label></h5>
+                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="閉じる">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-body">
+                                    <p class="text-center">一度退会するとデータはすべて削除され復旧はできません。</p>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn dashboard-delete-link" data-bs-dismiss="modal">キャンセル</button>
+                                    <button type="submit" class="btn samuraimart-delete-submit-button">退会する</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::controller(UserController::class)->group(function(){
     Route::get('users/mypage/password/edit', 'edit_password')->name('mypage.edit_password');
     Route::put('users/mypage/password', 'update_password')->name('mypage.update_password');
     Route::get('users/mypage/favorite', 'favorite')->name('mypage.favorite');
+    Route::delete('users/mypage/delete', 'destroy')->name('mypage.destroy');
 });
 
 Route::post('reviews', [ReviewController::class, 'store'])->name('reviews.store');


### PR DESCRIPTION
## 目的

- ユーザーが退会できるよう退会機能を追加する

## 実施事項

- 画面実装
  -  `退会ボタン`を 追加。
  - `退会ボタン`を押した際に`確認用モーダル`を表示。

- 退会処理を追加
  - `app/Http/Controllers/UserController`コントローラーに`destroy`アクションを追記。
    - 退会した際にユーザーの`deleted_flag`カラムを`0`から`1`に更新。
    - ログアウトが行われ、トップページへとリダイレクト。

- 退会ユーザーのログイン防止
  - `app/Http/Controllers/Auth/LoginController.php`コントローラーに`authenticated`メソッドを追加。
    - ログインを試みたユーザーの`deleted_flag`カラムの値で退会済みかを判定する処理を追加。
    - 退会済みユーザーはログインページへリダイレクト。
    - リダイレクト先の画面には退会済みメッセージを表示。

## UI

<img width="1512" alt="スクリーンショット 2023-11-07 22 09 40" src="https://github.com/tkhr-m/laravel-samuraimart/assets/101968075/e4a39bf7-7533-4bcc-81e8-f267ef6a69d9">

## テスト

- [会員情報編集ページ](http://localhost/laravel-samuraimart/public/users/mypage/edit)の退会機能の実施

## 確認依頼事項

- [会員情報編集ページ](http://localhost/laravel-samuraimart/public/users/mypage/edit)の退会機能の挙動が正しいか確認してください。
 
## 補足

- 特になし