### PR TITLE
新商品とおすすめ商品の表示

### DIFF
--- a/app/Admin/Controllers/ProductController.php
+++ b/app/Admin/Controllers/ProductController.php
@@ -33,6 +33,7 @@ class ProductController extends AdminController
         $grid->column('price', __('Price'))->sortable();
         $grid->column('category.name',__('Category Name'));
         $grid->column('image', __('Image'))->image();
+        $grid->column('recommend_flag', __('Recommend Flag'));
         $grid->column('created_at', __('Created at'))->sortable();
         $grid->column('updated_at', __('Updated at'))->sortable();
 
@@ -41,6 +42,7 @@ class ProductController extends AdminController
             $filter->like('description', '商品説明');
             $filter->between('price', '金額');
             $filter->in('category_id', 'カテゴリー')->multipleSelect(Category::all()->pluck('name', 'id'));
+            $filter->equal('recommend_flag', 'おすすめフラグ')->select(['0' => 'false', '1' => 'true']);
         });
 
         return $grid;
@@ -62,6 +64,7 @@ class ProductController extends AdminController
         $show->field('price', __('Price'));
         $show->field('category.name', __('Category Name'));
         $show->field('image', __('Image'))->image();
+        $show->field('recommend_flag', __('Recommend Flag'));
         $show->field('created_at', __('Created at'));
         $show->field('updated_at', __('Updated at'));
 
@@ -82,6 +85,7 @@ class ProductController extends AdminController
         $form->number('price', __('Price'));
         $form->select('category_id', __('Category Name'))->options(Category::all()->pluck('name', 'id'));
         $form->image('image', __('Image'));
+        $form->switch('recommend_flag', __('Recommend Flag'));
 
         return $form;
     }

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Category;
 use App\Models\MajorCategory;
+use App\Models\Product;
 
 class WebController extends Controller
 {
@@ -14,6 +15,10 @@ class WebController extends Controller
 
         $major_categories = MajorCategory::all();
 
-        return view('web.index', compact('categories', 'major_categories'));
+        $recently_products = Product::orderBy('created_at', 'desc')->take(4)->get();
+
+        $recommend_products = Product::where('recommend_flag', true)->take(3)->get();
+
+        return view('web.index', compact('categories', 'major_categories', 'recently_products', 'recommend_products'));
     }
 }

--- a/database/migrations/2023_11_05_215045_add_recommend_flag_toproducts.php
+++ b/database/migrations/2023_11_05_215045_add_recommend_flag_toproducts.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('recommend_flag')->defalut(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/web/index.blade.php
+++ b/resources/views/web/index.blade.php
@@ -9,106 +9,49 @@
     <div class="col-9">
         <h1>おすすめ商品</h1>
         <div class="row">
+            @foreach ($recommend_products as $recommend_product)
             <div class="col-4">
-                <a href="#">
-                    <img src="{{ asset('img/chestnut.jpg') }}" class="img-thumbnail">
+                <a href="{{route('products.show', $recommend_product)}}">
+                    @if ($recommend_product->image !== "")
+                    <img src="{{asset($recommend_product->image)}}" class="img-thumbnail">
+                    @else
+                    <img src="{{asset('img/dummn.png')}}" class="img-thumbnail">
+                    @endif
                 </a>
                 <div class="row">
-                    <div class="col-12">
+                    <div class="row-12">
                         <p class="samuraimart-product-label mt-2">
-                            和栗の詰め合わせ<br>
-                            <label>￥2000</label>
+                            {{$recommend_product->name}}<br>
+                            <label>￥{{$recommend_product->price}}</label>
                         </p>
                     </div>
                 </div>
             </div>
-            <div class="col-4">
-                <a href="#">
-                    <img src="{{ asset('img/persimmon.jpg') }}" class="img-thumbnail">
-                </a>
-                <div class="row">
-                    <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            おいしい柿<br>
-                            <label>￥500</label>
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-4">
-                <a href="#">
-                    <img src="{{ asset('img/orange.jpg') }}" class="img-thumbnail">
-                </a>
-                <div class="row">
-                    <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            旬なみかん<br>
-                            <label>￥1200</label>
-                        </p>
-                    </div>
-                </div>
-            </div>
-
+            @endforeach
         </div>
+
 
         <h1>新着商品</h1>
         <div class="row">
+            @foreach ($recently_products as $recently_product)
             <div class="col-3">
-                <a href="#">
-                    <img src="{{ asset('img/robot-vacuum-cleaner.jpg') }}" class="img-thumbnail">
+                <a href="{{route('products.show', $recently_product)}}">
+                    @if ($recently_product->image !== "")
+                    <img src="{{asset($recently_product->image)}}" class="img-thumbnail">
+                    @else
+                    <img src="{{asset('img/dummy.png')}}" class="img-thumbnail">
+                    @endif
                 </a>
                 <div class="row">
                     <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            ロボット掃除機<br>
-                            <label>￥55000</label>
+                         <p class="samuraimart-product-label mt-2">
+                            {{$recently_product->name}}<br>
+                             <label>￥{{$recently_product->price}}</label>
                         </p>
                     </div>
                 </div>
             </div>
-
-            <div class="col-3">
-                <a href="#">
-                    <img src="{{ asset('img/sofa.jpg') }}" class="img-thumbnail">
-                </a>
-                <div class="row">
-                    <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            3人掛けソファー<br>
-                            <label>￥35000</label>
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-3">
-                <a href="#">
-                    <img src="{{ asset('img/cup.jpg') }}" class="img-thumbnail">
-                </a>
-                <div class="row">
-                    <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            コーヒーカップ<br>
-                            <label>￥1000</label>
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-3">
-                <a href="#">
-                    <img src="{{ asset('img/cutlery.jpg') }}" class="img-thumbnail">
-                </a>
-                <div class="row">
-                    <div class="col-12">
-                        <p class="samuraimart-product-label mt-2">
-                            食器 カトラリーセット1組<br>
-                            <label>￥2000</label>
-                        </p>
-                    </div>
-                </div>
-            </div>
+            @endforeach
         </div>
     </div>
 </div>


### PR DESCRIPTION
## 目的

- トップページに新商品とおすすめ商品を表示させる

## 実施事項

- おすすめ商品用のカラム追加
  -  `products`テーブルに`boolean`型の`recommend_flag`カラム追加。初期値はfalse。
  - 商品管理画面から設定できるよう`app/Admin/Controllers/ProductController`コントローラの各アクションに`recommend_flag`カラム分の処理を追記。

- 新商品とおすすめ商品の取得
  - `app/Http/Controllers/WebController`コントローラの`index`アクションに、作成日時(`created_at`)が新しい商品を4件、おすすめ商品を3件取得し、`resources/views/web/index.blade.php`へと渡す処理を追記。
 
- 新商品とおすすめ商品の表示
  - `app/Http/Controllers/WebController`コントローラから渡されたデータをforeachで回して表示。

## UI

<img width="1512" alt="スクリーンショット 2023-11-10 13 18 02" src="https://github.com/tkhr-m/laravel-samuraimart/assets/101968075/02707af5-8755-40a5-8a4e-74a62e753e1e">

## テスト

- [トップページ](http://localhost/laravel-samuraimart/public/)へのアクセス

## 確認依頼事項

- [トップページ](http://localhost/laravel-samuraimart/public/)の挙動が正しいかご確認お願いします。

## 補足 

- 現在閲覧可能なリンクはありません。