### PR TITLE
売り上げ管理画面実装

### DIFF
--- a/app/Admin/Controllers/ProductController.php
+++ b/app/Admin/Controllers/ProductController.php
@@ -33,6 +33,7 @@ class ProductController extends AdminController
         $grid->column('price', __('Price'))->sortable();
         $grid->column('category.name',__('Category Name'));
         $grid->column('image', __('Image'))->image();
+        $grid->column('carriage_flag', __('Carriage Flag'));
         $grid->column('created_at', __('Created at'))->sortable();
         $grid->column('updated_at', __('Updated at'))->sortable();
 
@@ -41,6 +42,7 @@ class ProductController extends AdminController
             $filter->like('description', '商品説明');
             $filter->between('price', '金額');
             $filter->in('category_id', 'カテゴリー')->multipleSelect(Category::all()->pluck('name', 'id'));
+            $filter->equal('carriage_flag', '送料フラグ')->select(['0' => 'false', '1' => 'true']);
         });
 
         return $grid;
@@ -62,6 +64,7 @@ class ProductController extends AdminController
         $show->field('price', __('Price'));
         $show->field('category.name', __('Category Name'));
         $show->field('image', __('Image'))->image();
+        $show->field('carriage_flag', __('Carriage Flag'));
         $show->field('created_at', __('Created at'));
         $show->field('updated_at', __('Updated at'));
 
@@ -82,6 +85,7 @@ class ProductController extends AdminController
         $form->number('price', __('Price'));
         $form->select('category_id', __('Category Name'))->options(Category::all()->pluck('name', 'id'));
         $form->image('image', __('Image'));
+        $form->switch('carriage_flag', __('Carriage Flag'));
 
         return $form;
     }

--- a/app/Admin/Controllers/ShoppingCartController.php
+++ b/app/Admin/Controllers/ShoppingCartController.php
@@ -40,7 +40,7 @@ class ShoppingCartController extends AdminController
             $filter->between('created_at', '登録日')->datetime();
         });
 
-        $grid->diableCreateButton();
+        $grid->disableCreateButton();
         $grid->actions(function ($actions) {
             $actions->disableDelete();
             $actions->disableEdit();

--- a/app/Admin/Controllers/ShoppingCartController.php
+++ b/app/Admin/Controllers/ShoppingCartController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Admin\Controllers;
+
+use App\Models\ShoppingCart;
+use Encore\Admin\Controllers\AdminController;
+use Encore\Admin\Form;
+use Encore\Admin\Grid;
+use Encore\Admin\Show;
+
+class ShoppingCartController extends AdminController
+{
+    /**
+     * Title for current resource.
+     *
+     * @var string
+     */
+    protected $title = 'ShoppingCart';
+
+    /**
+     * Make a grid builder.
+     *
+     * @return Grid
+     */
+    protected function grid()
+    {
+        $grid = new Grid(new ShoppingCart());
+
+        $grid->column('identifier', __('ID'))->sortable();
+        $grid->column('instance', __('User ID'))->sortable();
+        $grid->column('price_total', __('Price total'))->totalRow();
+        $grid->column('qty', __('Qty'))->totalRow();
+        $grid->column('created_at', __('Created at'))->sortable();
+        $grid->column('updated_at', __('Updated at'))->sortable();
+
+        $grid->filter(function($filter) {
+            $filter->disableIdFilter();
+            $filter->equal('identifier', 'ID');
+            $filter->equal('instance', 'User ID');
+            $filter->between('created_at', '登録日')->datetime();
+        });
+
+        $grid->diableCreateButton();
+        $grid->actions(function ($actions) {
+            $actions->disableDelete();
+            $actions->disableEdit();
+            $actions->disableView();
+        });
+
+        return $grid;
+    }
+}

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -5,6 +5,7 @@ use App\Admin\Controllers\CategoryController;
 use App\Admin\Controllers\ProductController;
 use App\Admin\Controllers\MajoarCategoryController;
 use App\Admin\Controllers\UserController;
+use App\Admin\Controllers\ShoppingCartController;
 
 Admin::routes();
 
@@ -20,5 +21,6 @@ Route::group([
     $router->resource('products', ProductController::class);
     $router->resource('major-categories', MajorCategoryController::class);
     $router->resource('users', UserController::class);
+    $router->resource('shopping-carts', ShoppingCartController::class)->only('index');
 
 });

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -19,12 +19,22 @@ class CartController extends Controller
         $cart = Cart::instance(Auth::id())->content();
 
         $total = 0;
+        $has_carriage_cost = false;
+        $carriage_cost = 0;
 
-        foreach($cart as $c) {
+        foreach ($cart as $c) {
             $total += $c->qty * $c->price;
+            if ($c->options->carriage) {
+                $has_carriage_cost = true;
+            }
         }
 
-        return view('carts.index', compact('cart', 'total'));
+        if ($has_carriage_cost) {
+            $total += env('CARRIAGE');
+            $carriage_cost = env('CARRIAGE');
+        }
+
+        return view('carts.index', compact('cart', 'total', 'carriage_cost'));
     }
 
     /**
@@ -44,6 +54,7 @@ class CartController extends Controller
                 'weight' => $request->weight,
                 'options' => [
                     'image' => $request->image,
+                    'carriage' => $request->carriage,
                 ]
             ]
         );

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -71,13 +71,42 @@ class CartController extends Controller
     public function destroy(Request $request)
     {
         $user_shoppingcarts = DB::table('shoppingcart')->where('instance', Auth::id())->get();
+        $number = DB::table('shoppingcart')->where('instance', Auth::id())->count();
 
         $count = $user_shoppingcarts->count();
 
         $count += 1;
+        $number += 1;
+        $cart = Cart::instance(Auth::user()->id)->content();
+
+        $price_total = 0;
+        $qty_total = 0;
+        $has_carriage_cost = false;
+
+        foreach ($cart as $c) {
+            $price_total += $c->qty * $c->price;
+            $qty_total += $c->qty;
+            if ($c->options->carriage) {
+                $has_carriage_cost = true;
+            }
+        }
+
+        if ($has_carriage_cost) {
+            $price_total += env('CARRIAGE');
+        }
+
         Cart::instance(Auth::id())->store($count);
 
-        DB::table('shoppingcart')->where('instance', Auth::id())->where('number', null)->update(['number' => $count, 'buy_flag' => true]);
+        DB::table('shoppingcart')->where('instance', Auth::id())->where('number', null)->update(
+            [
+                'code' => substr(str_shuffle('1234567890abcdefghijklmnopqrstuvwxyz'), 0, 10),
+                'number' => $count,
+                'price_total' => $price_total,
+                'qty' => $qty_total,
+                'buy_flag' => true,
+                'updated_at' => date("Y/m/d H:i:s")
+            ]
+        );
 
         Cart::instance(Auth::id())->destroy();
 

--- a/app/Models/ShoppingCart.php
+++ b/app/Models/ShoppingCart.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ShoppingCart extends Model
+{
+    use HasFactory;
+
+    protected $table = 'shoppingcart';
+}

--- a/database/migrations/2023_11_06_213832_add_carriage_flag_to_products.php
+++ b/database/migrations/2023_11_06_213832_add_carriage_flag_to_products.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('carriage_flag')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2023_11_10_144949_add_columns_to_shoppingcart.php
+++ b/database/migrations/2023_11_10_144949_add_columns_to_shoppingcart.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shoppingcart', function (Blueprint $table) {
+            $table->string('code')->default("");
+            $table->integer('price_total')->unsigned()->default(0);
+            $table->integer('qty')->unsigned()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shoppingcart', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2023_11_10_144949_add_columns_to_shoppingcart.php
+++ b/database/migrations/2023_11_10_144949_add_columns_to_shoppingcart.php
@@ -28,7 +28,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('shoppingcart', function (Blueprint $table) {
-            //
+            // nothing to do
         });
     }
 };

--- a/resources/views/carts/index.blade.php
+++ b/resources/views/carts/index.blade.php
@@ -45,6 +45,19 @@
     <div class="offset-8 col-4">
       <div class="row">
         <div class="col-6">
+          <h2>送料</h2>
+        </div>
+        <div class="col-6">
+          <h2>￥{{$carriage_cost}}</h2>
+        </div>
+      </div>
+    </div>
+
+    <hr>
+
+    <div class="offset-8 col-4">
+      <div class="row">
+        <div class="col-6">
           <h2>合計</h2>
         </div>
         <div class="col-6">

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -32,6 +32,7 @@
                 <input type="hidden" name="name" value="{{$product->name}}">
                 <input type="hidden" name="price" value="{{$product->price}}">
                 <input type="hidden" name="image" value="{{$product->image}}">
+                <input type="hidden" name="carriage" value="{{$product->carriage_flag}}">
                 <div class="form-group row">
                     <label for="quantity" class="col-sm-2 col-form-label">数量</label>
                     <div class="col-sm-10">

--- a/resources/views/users/favorite.blade.php
+++ b/resources/views/users/favorite.blade.php
@@ -36,6 +36,7 @@
           <input type="hidden" name="name" value="{{App\Models\Product::find($fav->favoriteable_id)->name}}">
           <input type="hidden" name="price" value="{{App\Models\Product::find($fav->favoriteable_id)->price}}">
           <input type="hidden" name="image" value="{{App\Models\Product::find($fav->favoriteable_id)->image}}">
+          <input type="hidden" name="carriage" value="{{App\Models\Product::find($fav->favoriteable_id)->carriage_flag}}">
           <input type="hidden" name="qty" value="1">
           <input type="hidden" name="weight" value="0">
           <button type="submit" class="btn samuraimart-favorite-add-cart">カートに入れる</button>


### PR DESCRIPTION
## 目的

- 売り上げを管理できるようにする

## 実施項目

- カラム追加
  - `shoppingcart`テーブルに`code`, `total_price`, `qty`カラムを追加。

- 売り上げ情報の保存処理追記
  - `app/Http/Controllers/CartController`コントローラの`destroy`アクションに、新たに追加した`code`, `total_price`, `qty`カラムの値も保存できるよう処理を追記。

- 売り上げ管理画面追加
  - `app\Models\ShoppingCart`モデルと`app\Admin\Controllers\ShoppingCartController`コントローラを作成。
    - コントローラには管理画面に売り上げデータを一覧表示する`grid`メソッドのみ残し、編集と詳細表示を行う`form`メソッドと`show`メソッドは削除。
    - `grid`メソッドには、管理画面から新しい売り上げデータを作成できないよう`disableCreateButton`メソッドを追記。
       さらに、削除・編集・詳細表示を無効化する`disableDelete`, `disableEdit`, `disableView`メソッドを追記。
  - `app\Admin\routes`ファイルに売り上げ管理画面を表示する為のルートを追記。

## UI

<img width="1512" alt="スクリーンショット 2023-11-10 18 30 37" src="https://github.com/tkhr-m/laravel-samuraimart/assets/101968075/eced92d6-0831-4d14-af57-5b0ef70fd96d">

## テスト

- [売り上げ管理画面](http://localhost/laravel-samuraimart/public/admin/shopping-carts)へのアクセス

## 確認依頼事項

- [売り上げ管理画面](http://localhost/laravel-samuraimart/public/admin/shopping-carts)の挙動が正しいか確認お願いします。

## 補足

- 現在閲覧可能なリンクはありません。
