### PR TITLE
注文履歴画面実装

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -6,6 +6,10 @@ use App\Models\User;
 use App\Models\Product;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use App\Models\ShoppingCart;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Gloudemans\Shoppingcart\Facades\Cart;
+use Illuminate\Support\Facades\DB;
 
 
 class UserController extends Controller
@@ -97,5 +101,42 @@ class UserController extends Controller
 
         Auth::logout();
         return redirect('/');
+    }
+
+    public function cart_history_index(Request $request)
+    {
+        $page = $request->page != null ? $request->page : 1;
+        $user_id = Auth::user()->id;
+        $billings = ShoppingCart::getCurrentUserOrders($user_id);
+        $total = count($billings);
+        $billings = new LengthAwarePaginator(array_slice($billings, ($page - 1) * 15, 15), $total, 15, $page, array('path' => $request->url()));
+
+        return view('users.cart_history_index', compact('billings', 'total'));
+    }
+
+    public function cart_history_show(Request $request)
+    {
+        $num = $request->num;
+        $user_id = Auth::id();
+        $cart_info = DB::table('shoppingcart')->where('instance', $user_id)->where('number', $num)->get()->first();
+        Cart::instance($user_id)->restore($cart_info->identifier);
+        $cart_contents = Cart::content();
+        Cart::instance($user_id)->store($cart_info->identifier);
+        Cart::destroy();
+
+        DB::table('shoppingcart')->where('instance', $user_id)
+            ->where('number', null)
+            ->update(
+                [
+                    'code' => $cart_info->code,
+                    'number' => $num,
+                    'price_total' => $cart_info->price_total,
+                    'qty' => $cart_info->qty,
+                    'buy_flag' => $cart_info->buy_flag,
+                    'updated_at' => $cart_info->updated_at
+                ]
+            );
+
+        return view('users.cart_history_show', compact('cart_contents', 'cart_info'));
     }
 }

--- a/app/Models/ShoppingCart.php
+++ b/app/Models/ShoppingCart.php
@@ -4,10 +4,30 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class ShoppingCart extends Model
 {
     use HasFactory;
 
     protected $table = 'shoppingcart';
+
+    public static function getCurrentUserOrders($user_id)
+    {
+        $shoppingcarts = DB::table('shoppingcart')->where("instance", "{$user_id}")->get();
+
+        $orders = [];
+
+        foreach ($shoppingcarts as $order) {
+            $orders[] = [
+                'id' => $order->number,
+                'created_at' => $order->updated_at,
+                'total' => $order->price_total,
+                'user_name' => User::find($order->instance)->name,
+                'code' => $order->code
+            ];
+        }
+
+        return $orders;
+    }
 }

--- a/resources/views/users/cart_history_index.blade.php
+++ b/resources/views/users/cart_history_index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <span>
+                <a href="{{ route('mypage') }}">マイページ</a> > 注文履歴
+            </span>
+
+            <div class="container mt-4">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th scope="col">注文番号</th>
+                            <th scope="col">購入日時</th>
+                            <th scope="col">合計金額</th>
+                            <th scope="col">詳細</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($billings as $billing)
+                        <tr>
+                            <td>{{ $billing['code'] }}</td>
+                            <td>{{ $billing['created_at'] }}</td>
+                            <td>{{ $billing['total'] }}</td>
+                            <td>
+                                <a href="{{ route('mypage.cart_history_show', $billing['id']) }}">
+                                     詳細を確認する
+                                </a>
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            {{ $billings->links() }}
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/resources/views/users/cart_history_show.blade.php
+++ b/resources/views/users/cart_history_show.blade.php
@@ -1,0 +1,108 @@
+ @extends('layouts.app')
+
+ @section('content')
+ <div class="container">
+     <div class="row justify-content-center">
+         <div class="col-md-8">
+             <span>
+                 <a href="{{ route('mypage') }}">マイページ</a> > <a href="{{ route('mypage.cart_history') }}">注文履歴</a> > 注文履歴詳細
+             </span>
+
+             <h1 class="mt-3">注文履歴詳細</h1>
+
+             <h4 class="mt-3">ご注文情報</h4>
+
+             <hr>
+
+             <div class="row">
+                 <div class="col-5 mt-2">
+                     注文番号
+                 </div>
+                 <div class="col-7 mt-2">
+                     {{ $cart_info->code }}
+                 </div>
+
+                 <div class="col-5 mt-2">
+                     注文日時
+                 </div>
+                 <div class="col-7 mt-2">
+                     {{ $cart_info->updated_at }}
+                 </div>
+
+                 <div class="col-5 mt-2">
+                     合計金額
+                 </div>
+                 <div class="col-7 mt-2">
+                     {{ $cart_info->price_total }}円
+                 </div>
+
+                 <div class="col-5 mt-2">
+                     合計数量
+                 </div>
+                 <div class="col-7 mt-2">
+                     {{ $cart_info->qty }}
+                 </div>
+             </div>
+
+             <hr>
+
+             <div class="row">
+                 @foreach ($cart_contents as $product)
+                 <div class="col-md-5 mt-2">
+                     <a href="{{ route('products.show', $product->id) }}" class="ml-4">
+                         @if ($product->options->image)
+                         <img src="{{ asset($product->options->image) }}" class="img-fluid w-75">
+                         @else
+                         <img src="{{ asset('img/dummy.png') }}" class="img-fluid w-75">
+                         @endif
+                     </a>
+                 </div>
+                 <div class="col-md-7 mt-2">
+                     <div class="flex-column">
+                         <p class="mt-4">{{$product->name}}</p>
+                         <div class="row">
+                             <div class="col-2 mt-2">
+                                 数量
+                             </div>
+                             <div class="col-10 mt-2">
+                                 {{$product->qty}}
+                             </div>
+
+                             <div class="col-2 mt-2">
+                                 小計
+                             </div>
+                             <div class="col-10 mt-2">
+                                 ￥{{$product->qty * $product->price}}
+                             </div>
+
+                             <div class="col-2 mt-2">
+                                 送料
+                             </div>
+                             <div class="col-10 mt-2">
+                                 @if ($product->options->carriage)
+                                 ￥800
+                                 @else
+                                 ￥0
+                                 @endif
+                             </div>
+
+                             <div class="col-2 mt-2">
+                                 合計
+                             </div>
+                             <div class="col-10 mt-2">
+                                 @if ($product->options->carriage)
+                                 ￥{{($product->qty * $product->price) + 800}}
+                                 @else
+                                 ￥{{$product->qty * $product->price}}
+                                 @endif
+                             </div>
+                         </div>
+                     </div>
+                 </div>
+                 @endforeach
+             </div>
+         </div>
+     </div>
+ </div>
+
+ @endsection

--- a/resources/views/users/mypage.blade.php
+++ b/resources/views/users/mypage.blade.php
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="d-flex align-items-center">
-          <a href="{{route('mypage')}}">
+          <a href="{{route('mypage.cart_history')}}">
             <i class="fas fa-chevron-right fa-2x"></i>
           </a>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,8 @@ Route::controller(UserController::class)->group(function(){
     Route::put('users/mypage/password', 'update_password')->name('mypage.update_password');
     Route::get('users/mypage/favorite', 'favorite')->name('mypage.favorite');
     Route::delete('users/mypage/delete', 'destroy')->name('mypage.destroy');
+    Route::get('users/mypage/cart_history', 'cart_history_index')->name('mypage.cart_history');
+    Route::get('users/mypage/cart_history/{num}', 'cart_history_show')->name('mypage.cart_history_show');
 });
 
 Route::post('reviews', [ReviewController::class, 'store'])->name('reviews.store');


### PR DESCRIPTION
## 目的
- 注文履歴を一覧で見れるようにする
- 注文履歴の詳細を見れるようにする

## 実施事項
- 注文履歴一覧の画面実装
  - モデル`app\Models\ShoppingCart.php`を編集。ユーザの注文履歴を取得する処理`getCurrentUserOrders()`を追記。
  - コントローラ`app/Http/Controllers/UserController.php`編集。注文履歴を一覧表示する`cart_history_index`アクションを作成。
  - 注文履歴を一覧表示するためのビュー`resources/views/users/cart_history_index.blade.php`を作成。'$billings->links()'でページネーションを設定。
  - `routes/web.php`ファイルにルーティングを追加。
  - マイページ`resources/views/users/mypage.blade.php`に注文履歴一覧ページのリンクを設置。

- 注文履歴詳細の画面実装
  - コントローラ`app/Http/Controllers/UserController.php`編集。注文番号を指定して注文データを取得する`cart_history_show`アクションを作成。
  - コントローラ`app/Http/Controllers/UserController.php`で取得した注文データを表示するビュー`resources/views/users/cart_history_show.blade.php`を作成。
  -  `routes/web.php`ファイルにルーティングを追加。

## UI

- 注文履歴一覧
<img width="1512" alt="スクリーンショット 2023-11-15 20 59 32" src="https://github.com/tkhr-m/laravel-samuraimart/assets/101968075/1b5999c0-04c3-4a36-83a4-e8388a3f05d9">

- 注文詳細
<img width="1512" alt="スクリーンショット 2023-11-15 21 00 45" src="https://github.com/tkhr-m/laravel-samuraimart/assets/101968075/b84e3a1d-b347-4503-b9ba-cf873128bb2a">

## テスト
- [マイページ](http://localhost/laravel-samuraimart/public/users/mypage)から注文履歴一覧ページ、注文詳細ページへアクセス。

## 確認依頼事項
- [マイページ](http://localhost/laravel-samuraimart/public/users/mypage)から注文履歴一覧ページ、注文詳細ページへとアクセスし、挙動が正しいかの確認よろしくお願いします。

## 補足
- 現在サイトの公開場所がありません